### PR TITLE
[serveur][sub] PR fonctionnelle jusqu'àu début de partie: les trois instances communiquent!

### DIFF
--- a/server/model/game_manager.c
+++ b/server/model/game_manager.c
@@ -95,7 +95,7 @@ int		energy_fall(t_game_info **info)
   power = rand() % (16 - 5) + 5;
   if (count_ecs((*info)->energy_cells, map_size) == 0)
     {
-      if (map->is_free_square(x, y, (*info)->players, (*info)->energy_cells))
+      if (map->is_energy_cell(x, y, (*info)->energy_cells) == NULL)
 	{
 	  if ((ecs = create_energy_cell(x, y, power)) == NULL)
 	    return (1);

--- a/server/src/server/thread.c
+++ b/server/src/server/thread.c
@@ -118,7 +118,7 @@ void 		*tic_thread(void *manager)
 	}
       json = game_info_to_json(thread->info);
       sprintf(output, "%s %d %s", "Softwar", CYCLE, json_object_to_json_string(json));
-      // my_log(__func__, output, 5);
+      my_log(__func__, output, 5);
       zstr_sendf(pub, "%s %d %s", "Softwar", CYCLE, json_object_to_json_string(json));
       if (energy_fall(&thread->info))
 	pthread_exit(NULL);

--- a/sub/client_sub.py
+++ b/sub/client_sub.py
@@ -72,7 +72,7 @@ def my_json(win, messagedata):
             draw_client(win, pl_x, pl_y, pl_identity, gap)
         
 def socket(win):
-    port = "5556"
+    port = "4243"
     if len(sys.argv) > 1:
         port = sys.argv[1]
         int(port)


### PR DESCRIPTION
 fix energy_fall: is_free_square devient is_energy_cell, permet de corriger le plantage lorsqu'un joueur est connecté avant que le plateau soit plein. 
thread.c: remise en route du log, vous pouvez virer l'affichage console avec l'option -ticfile [filepath.log] qui loggera le tic dans un fichier. 
[sub] port défault 5556 => 4243.